### PR TITLE
Fix Canvas Zoom for JavaFX 13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ buildNumber.properties
 
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar
+
+# IntelliJ
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,15 @@
 				</configuration>
 			</plugin>
 
+            <plugin>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>0.0.4</version>
+                <configuration>
+                    <mainClass>com.fxgraph.graph.MainApp</mainClass>
+                </configuration>
+            </plugin>
+
 		</plugins>
 	</build>
 
@@ -191,6 +200,11 @@
 			<artifactId>org.abego.treelayout.core</artifactId>
 			<version>1.0.3</version>
 		</dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>13</version>
+        </dependency>
 	</dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -73,15 +73,6 @@
 				</configuration>
 			</plugin>
 
-            <plugin>
-                <groupId>org.openjfx</groupId>
-                <artifactId>javafx-maven-plugin</artifactId>
-                <version>0.0.4</version>
-                <configuration>
-                    <mainClass>com.fxgraph.graph.MainApp</mainClass>
-                </configuration>
-            </plugin>
-
 		</plugins>
 	</build>
 
@@ -200,11 +191,6 @@
 			<artifactId>org.abego.treelayout.core</artifactId>
 			<version>1.0.3</version>
 		</dependency>
-        <dependency>
-            <groupId>org.openjfx</groupId>
-            <artifactId>javafx-controls</artifactId>
-            <version>13</version>
-        </dependency>
 	</dependencies>
 
 </project>

--- a/src/main/java/com/fxgraph/graph/ViewportGestures.java
+++ b/src/main/java/com/fxgraph/graph/ViewportGestures.java
@@ -88,7 +88,7 @@ public class ViewportGestures {
 
 			if(event.getDeltaY() < 0) {
 				scale /= getZoomSpeed();
-			} else {
+			} else if (event.getDeltaY() > 0) {
 				scale *= getZoomSpeed();
 			}
 


### PR DESCRIPTION
This PR fixes #5. I tested it manually with the demo code on both JavaFX 8 and 13. As far as I can tell, it fixes the zooming behavior for 13 without changing it for 8.